### PR TITLE
Fix issue with linking external dependencies properly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ go get -u github.com/pilu/fresh
 ## Start
 ```
 ➜  govendor sync
+➜  govendor add +external
 ➜  fresh
 ```
 


### PR DESCRIPTION
Without linking the external dependencies, `fresh` cannot properly build this repo.